### PR TITLE
Fixes writing bool as UInt8 instead of Int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 2.1.2
+
+- Fixes writing bool as UInt8 instead of Int
+
 ## 2.1.1
 
 - Fixes FileStream to create a file if it does not exists.

--- a/Sources/BinaryHandler/BinaryWriter.swift
+++ b/Sources/BinaryHandler/BinaryWriter.swift
@@ -56,7 +56,7 @@ extension BinaryWritable {
     }
 
     public func write(_ value: Bool) throws {
-        try write(value ? 1 : 0)
+        try write(UInt8(value ? 1 : 0))
     }
 
     public func writeFixedString(_ value: String) throws {

--- a/Tests/BinaryHandlerTests/BinaryHandlerTests.swift
+++ b/Tests/BinaryHandlerTests/BinaryHandlerTests.swift
@@ -3,6 +3,21 @@ import XCTest
 
 final class BinaryHandlerTests: XCTestCase {
 
+    func testWriteReadBool() throws {
+        let stream = MemoryStream(withData: Data())
+        let writer = BinaryWriter(source: stream)
+
+        try writer.write(false)
+        try writer.write(true)
+        
+        let reader = BinaryReader(source: stream)
+        try reader.seekTo(position: 0) // Reset position for reading
+
+        XCTAssertEqual(try? reader.readBool(), false)
+        XCTAssertEqual(try? reader.readBool(), true)
+        XCTAssertEqual(stream.data.count, 2)
+    }
+    
     func testWriteReadUint8() throws {
         let stream = MemoryStream(withData: Data())
         let writer = BinaryWriter(source: stream)


### PR DESCRIPTION
Bool value was being written as a Int number, making it 8 bytes long, but reading it was expecting a Uint8 just reading one byte.